### PR TITLE
Enable syntax highlighting

### DIFF
--- a/content/blog/prop-naming/index.md
+++ b/content/blog/prop-naming/index.md
@@ -40,7 +40,7 @@ Now let's say we also want to list out the items in our `MusicCollection`. We ha
 
 What happens if we want to reuse the `ListItem` component for this new purpose?
 
-```js
+```jsx
 const MusicCollection = ({cds, records}) => (
   <div>
     <h1>Your music collection</h1>

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,3 +1,6 @@
 // custom typefaces
-import "typeface-montserrat"
-import "typeface-merriweather"
+import 'typeface-montserrat'
+import 'typeface-merriweather'
+
+// prism theme
+import 'prism-themes/themes/prism-ghcolors.css'

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "gatsby-source-filesystem": "^2.1.21",
     "gatsby-transformer-remark": "^2.6.21",
     "gatsby-transformer-sharp": "^2.2.13",
+    "prism-themes": "^1.2.0",
     "prismjs": "^1.17.1",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9789,6 +9789,11 @@ pretty-error@^2.1.1:
     renderkid "^2.0.1"
     utila "~0.4"
 
+prism-themes@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/prism-themes/-/prism-themes-1.2.0.tgz#a9f5e5e14a82d7cf4fa77a43f8ddcce72952799e"
+  integrity sha512-Y+xZs8u++9IHPZOIaeQ6itdTuDMNcGv0tMIO8MA6AlV9ZocdBvhy1JU6SE/Yzg+8RwSvWLYDQx85ardSKxo/9g==
+
 prismjs@^1.17.1:
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.17.1.tgz#e669fcbd4cdd873c35102881c33b14d0d68519be"


### PR DESCRIPTION
Uses the `prism-ghcolors` theme. Also adds a missing `jsx` language tag to a codeblock in `content/blog/prop-naming`.